### PR TITLE
Handle invalid RSS pubDate parsing

### DIFF
--- a/multi_agent_crypto/agents/news_agent.py
+++ b/multi_agent_crypto/agents/news_agent.py
@@ -74,7 +74,13 @@ class NewsAgent(BaseAgent):
             link = (item.findtext("link") or "").strip()
             description = (item.findtext("description") or "").strip()
             pub_date_raw = item.findtext("pubDate")
-            published_at = parsedate_to_datetime(pub_date_raw) if pub_date_raw else datetime.now(timezone.utc)
+            if pub_date_raw:
+                try:
+                    published_at = parsedate_to_datetime(pub_date_raw)
+                except (ValueError, TypeError):
+                    published_at = datetime.now(timezone.utc)
+            else:
+                published_at = datetime.now(timezone.utc)
             uid_basis = f"{source.name}:{link or title}"
             article_id = hashlib.sha256(uid_basis.encode("utf-8")).hexdigest()
             symbols = self._detect_symbols(title, description)

--- a/tests/test_news_agent.py
+++ b/tests/test_news_agent.py
@@ -1,0 +1,31 @@
+from datetime import timezone
+
+from multi_agent_crypto.agents.news_agent import NewsAgent, NewsSource
+
+
+def test_parse_rss_handles_invalid_pubdate():
+    agent = NewsAgent(
+        sources=[NewsSource(name="UnitTest", url="https://example.com/rss")],
+        tracked_symbols=["BTC"],
+    )
+    raw_xml = """<?xml version='1.0' encoding='UTF-8'?>
+    <rss version='2.0'>
+        <channel>
+            <title>Unit Test Feed</title>
+            <item>
+                <title>BTC rally continues</title>
+                <link>https://example.com/articles/btc</link>
+                <description>Market observers discuss the latest BTC surge.</description>
+                <pubDate>not-a-valid-date</pubDate>
+            </item>
+        </channel>
+    </rss>
+    """
+
+    source = agent.sources[0]
+    articles = agent._parse_rss(raw_xml, source)
+
+    assert len(articles) == 1
+    article = articles[0]
+    assert article.title == "BTC rally continues"
+    assert article.published_at.tzinfo == timezone.utc


### PR DESCRIPTION
## Summary
- fall back to the current UTC time when RSS pubDate parsing fails in the news agent
- add a unit test covering an RSS item with an invalid pubDate

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68d08536eb488333a388789c86e21266