### PR TITLE
Handle redirects in news agent RSS fetch

### DIFF
--- a/multi_agent_crypto/agents/news_agent.py
+++ b/multi_agent_crypto/agents/news_agent.py
@@ -54,7 +54,7 @@ class NewsAgent(BaseAgent):
         return state
 
     async def _fetch_source(self, client: httpx.AsyncClient, source: NewsSource) -> List[NewsArticle]:
-        response = await client.get(source.url)
+        response = await client.get(source.url, follow_redirects=True)
         response.raise_for_status()
         return self._parse_rss(response.text, source)
 

--- a/tests/test_news_agent.py
+++ b/tests/test_news_agent.py
@@ -1,4 +1,7 @@
+import asyncio
 from datetime import timezone
+
+import httpx
 
 from multi_agent_crypto.agents.news_agent import NewsAgent, NewsSource
 
@@ -29,3 +32,45 @@ def test_parse_rss_handles_invalid_pubdate():
     article = articles[0]
     assert article.title == "BTC rally continues"
     assert article.published_at.tzinfo == timezone.utc
+
+
+def test_fetch_source_follows_redirect():
+    redirect_url = "https://example.com/rss"
+    final_url = "https://example.com/rss-final"
+    rss_body = """<?xml version='1.0' encoding='UTF-8'?>
+    <rss version='2.0'>
+        <channel>
+            <title>Unit Test Feed</title>
+            <item>
+                <title>BTC rally continues</title>
+                <link>https://example.com/articles/btc</link>
+                <description>Market observers discuss the latest BTC surge.</description>
+                <pubDate>Wed, 01 May 2024 15:00:00 GMT</pubDate>
+            </item>
+        </channel>
+    </rss>
+    """
+
+    agent = NewsAgent(
+        sources=[NewsSource(name="UnitTest", url=redirect_url)],
+        tracked_symbols=["BTC"],
+    )
+    source = agent.sources[0]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url == httpx.URL(redirect_url):
+            return httpx.Response(307, headers={"Location": final_url})
+        if request.url == httpx.URL(final_url):
+            return httpx.Response(200, text=rss_body)
+        raise AssertionError(f"Unexpected URL requested: {request.url}")
+
+    transport = httpx.MockTransport(handler)
+
+    async def run_fetch() -> list:
+        async with httpx.AsyncClient(transport=transport) as client:
+            return await agent._fetch_source(client, source)
+
+    articles = asyncio.run(run_fetch())
+
+    assert len(articles) == 1
+    assert articles[0].title == "BTC rally continues"


### PR DESCRIPTION
## Summary
- allow the news agent to follow HTTP redirects when fetching RSS feeds
- add a regression test that simulates a redirecting RSS endpoint

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68d098baa68c833391cc29229b6457a3