### PR TITLE
Ensure pytest resolves project package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration ensuring project package import resolution."""
+
+import sys
+from pathlib import Path
+
+# Insert the project root into sys.path before any project imports.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+project_root_str = str(PROJECT_ROOT)
+if project_root_str not in sys.path:
+    sys.path.insert(0, project_root_str)


### PR DESCRIPTION
## Summary
- add a pytest conftest that injects the project root into `sys.path` so `multi_agent_crypto` imports succeed when running tests directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d09d2cd27c8333bf4eb8832ff430ba