### PR TITLE
Add aiofiles dependency to monitoring extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
 monitoring = [
     "fastapi>=0.110",
     "uvicorn>=0.22",
+    "aiofiles>=23",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add aiofiles to the monitoring optional dependencies so FastAPI static files can be served

## Testing
- pip install -e .[monitoring]
- python -m multi_agent_crypto.monitoring
- curl -i http://127.0.0.1:8000/


------
https://chatgpt.com/codex/tasks/task_b_68d0d325a4448333acd9445906da8e6e